### PR TITLE
Feature/support time extracted

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-taboola',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_taboola'],
       install_requires=[
-          'singer-python==0.2.1',
+          'singer-python==5.0.4',
           'backoff==1.3.2',
           'requests==2.12.4',
           'python-dateutil==2.6.0'


### PR DESCRIPTION
singer-python version 5.0.0 introduced `time_extracted` for the `RecordMessage`. We are now going to support these in tap-taboola.