### PR TITLE
feat: add campaign_name and conversions_value

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-taboola',
-      version='0.2.1',
+      version='0.3.0',
       description='Singer.io tap for extracting data from the Taboola API',
       author='Fishtown Analytics',
       url='http://www.singer.io',

--- a/tap_taboola/__init__.py
+++ b/tap_taboola/__init__.py
@@ -132,6 +132,8 @@ def parse_campaign_performance(campaign_performance):
             campaign_performance.get('date'),
             '%Y-%m-%d %H:%M:%S.%f'
         ).date()),
+        'campaign_name': str(campaign_performance.get('campaign_name', '')),
+        'conversions_value': float(campaign_performance.get('conversions_value', 0.0)),
     }
 
 def fetch_campaign_performance(config, state, access_token, account_id):

--- a/tap_taboola/schemas.py
+++ b/tap_taboola/schemas.py
@@ -129,6 +129,10 @@ campaign_performance = {
             'type': 'integer',
             'description': 'Total number of impressions',
         },
+        'campaign_name': {
+            'type': 'string',
+            'description': 'Human-readable campaign name',
+        },
         'ctr': {
             'type': 'number',
             'description': 'CTR, calculated as clicks/impressions',
@@ -161,6 +165,10 @@ campaign_performance = {
         'spent': {
             'type': 'number',
             'description': 'Total spent amount',
+        },
+        'conversions_value': {
+            'type': 'number',
+            'description': 'Total revenue from conversions',
         },
         'currency': {
             'type': 'string',

--- a/tap_taboola/schemas.py
+++ b/tap_taboola/schemas.py
@@ -130,7 +130,7 @@ campaign_performance = {
             'description': 'Total number of impressions',
         },
         'campaign_name': {
-            'type': 'string',
+            'type': ['string', 'null'],
             'description': 'Human-readable campaign name',
         },
         'ctr': {
@@ -167,7 +167,7 @@ campaign_performance = {
             'description': 'Total spent amount',
         },
         'conversions_value': {
-            'type': 'number',
+            'type': ['number', 'null'],
             'description': 'Total revenue from conversions',
         },
         'currency': {


### PR DESCRIPTION
# Description of change
The endpoint requested is already returning `campaign_name` and `conversions_value`. The AIM of this PR is just to parse them in the same way as the other values and add them to the `campaign_performance` schema.

* `campaign_name` is returned specifically because the dimension `campaign_day_breakdown` is requested [here](https://github.com/singer-io/tap-taboola/blob/master/tap_taboola/__init__.py#L138) ([doc](https://developers.taboola.com/backstage-api/reference/dimensions-cheat-sheet))
* `conversions_value` is returned for all dimensions ([doc](https://developers.taboola.com/backstage-api/reference/campaign-summary-fixed-columns))

# Manual QA steps
 - tested locally
 
# Risks
 - N/A
 
# Rollback steps
 - revert this branch
