### PR TITLE
update tap version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## 0.3.0
+## 0.3.1
   * add campaign_name and conversions_value in campaign_performance stream  [#13](https://github.com/singer-io/tap-taboola/pull/13)
   * update singer-python, backoff, and requests package [#15](https://github.com/singer-io/tap-taboola/pull/15)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-taboola',
-      version='0.3.0',
+      version='0.3.1',
       description='Singer.io tap for extracting data from the Taboola API',
       author='Fishtown Analytics',
       url='http://www.singer.io',


### PR DESCRIPTION
# Description of change
PyPI isn't allowing tap version 0.3.0 to be redeployed. Therefore, upgrading the tap version to 0.3.1.

# Manual QA steps
 - NA
 
# Risks
 - NA
 
# Rollback steps
 - revert this branch
